### PR TITLE
docs: Delete any reference that may imply that we support multiple repo paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ cargo build --release
 
 ## Quick Start
 
+**Note:** Only one path argument is supported.
+
 ```bash
 # Scan current directory
 ./cli-rust .

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,8 +20,9 @@ use clap::Parser;
 #[command(about = "Package repository context for LLMs")]
 /// Main CLI structure for the application.
 pub struct Cli {
-    /// Path to analyze
-    pub path: String,
+    /// Repository root path
+    #[arg(help = "Repository root path (only one path allowed)")]
+    pub repo_path: String,
 
     /// Toggle Recursive file traversal
     #[arg(short, long, default_value_t = true)] // NOTE: Haven't tested this yet

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     let config = Config {
-        root_path: cli.path,
+        root_path: cli.repo_path,
         output_file: cli.output,
         include_patterns: cli.include.unwrap_or_default(),
         exclude_patterns: cli.exclude.unwrap_or_default(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,7 +16,7 @@
 
 #[derive(Debug, Clone)]
 pub struct Config {
-    // I'm against multiple paths in this release(0.1), but we can support it later.
+    // will only support the original repo path
     pub root_path: String,
     pub output_file: Option<String>,
     pub include_patterns: Vec<String>,


### PR DESCRIPTION
Pretty ambiguous issue. My comments on code may have implied multiple root path support however that really doesn't make a lot of sense in our context.