### PR TITLE
Issue 27: Add support for `--recent` flag to filter recently modified files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A simple Rust CLI tool that packages your codebase for LLMs. It scans directorie
 - 📝 Extracts text file contents (skips binary files)
 - 🔄 Git repository information
 - 🎯 Glob pattern filtering
+- ⏰ Recent files filtering (last 7 days)
 
 ## Installation
 
@@ -42,6 +43,9 @@ cargo build --release
 
 # Save to file
 ./cli-rust . -o output.txt
+
+# Only include files modified in the last 7 days
+./cli-rust . --recent
 ```
 
 ## Command Options
@@ -52,6 +56,7 @@ cargo build --release
 | `-e, --exclude` | Exclude file patterns (e.g., "target/*") |
 | `-o, --output` | Save to file instead of stdout |
 | `-r, --recursive` | Recursive scanning (default: true) |
+| `--recent` | Only include files modified within the last 7 days |
 
 ## Dependencies
 
@@ -86,6 +91,12 @@ Examples:
 
 # Combine include + exclude
 ./cli-rust . --include 'src/**/*.rs' --exclude 'src/generated/**'
+
+# Only recent files (last 7 days)
+./cli-rust . --recent
+
+# Combine recent with include patterns
+./cli-rust . --recent --include 'src/**/*.rs' --output recent_changes
 ```
 
 Gotchas:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,4 +39,8 @@ pub struct Cli {
     /// Include dir/file patterns
     #[arg(short = 'i', long = "include")]
     pub include: Option<Vec<String>>,
+
+    /// Only include files modified within the last 7 days
+    #[arg(long = "recent")]
+    pub recent: bool,
 }

--- a/src/files.rs
+++ b/src/files.rs
@@ -86,8 +86,7 @@ impl FileContext {
                         Err(e) => {
                             eprintln!(
                                 "Warning: Could not check modification time for {}: {}",
-                                abs_target_path,
-                                e
+                                abs_target_path, e
                             );
                             continue;
                         }

--- a/src/files.rs
+++ b/src/files.rs
@@ -30,7 +30,7 @@ fn get_file_lines(path: &Path) -> Result<u64, Box<dyn std::error::Error>> {
     Ok(reader.lines().count() as u64)
 }
 
-/// Check if a file was modified within the last 7 days
+/// Filter fn: Check if a file was modified within the last 7 days
 fn is_recently_modified(path: &Path) -> Result<bool, Box<dyn std::error::Error>> {
     let metadata = fs::metadata(path)?;
     let modified_time = metadata.modified()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         include_patterns: cli.include.unwrap_or_default(),
         exclude_patterns: cli.exclude.unwrap_or_default(),
         is_recursive: cli.recursive,
+        recent_only: cli.recent,
     };
 
     let mut manager = ContextManager::new(config.clone());

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -17,9 +17,9 @@
 use crate::Config;
 use globset::{Glob, GlobSetBuilder};
 use ptree::TreeBuilder;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
-use std::fs;
 
 /// Check if a file was modified within the last 7 days
 fn is_recently_modified(path: &Path) -> Result<bool, Box<dyn std::error::Error>> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -24,6 +24,7 @@ pub struct Config {
     pub include_patterns: Vec<String>,
     pub exclude_patterns: Vec<String>,
     pub is_recursive: bool,
+    pub recent_only: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/tests/code_block_tests.rs
+++ b/tests/code_block_tests.rs
@@ -44,6 +44,7 @@ fn test_code_block_formatting() {
         include_patterns: vec![],
         exclude_patterns: vec![],
         is_recursive: false,
+        recent_only: false,
     };
 
     let file_ctx = FileContext::from_root(config.clone(), temp_dir.path().to_str().unwrap())
@@ -105,6 +106,7 @@ fn test_file_without_extension() {
         include_patterns: vec![],
         exclude_patterns: vec![],
         is_recursive: false,
+        recent_only: false,
     };
 
     let file_ctx = FileContext::from_root(config.clone(), temp_dir.path().to_str().unwrap())

--- a/tests/files/include_exclude.rs
+++ b/tests/files/include_exclude.rs
@@ -37,6 +37,7 @@ fn exclude_glob_filters_out_matches() {
         include_patterns: vec![],
         exclude_patterns: vec!["**/*.log".into(), "**/*.bin".into()],
         is_recursive: true,
+        recent_only: false,
     };
 
     let file_ctx = FileContext::from_root(config.clone(), &config.root_path).unwrap();
@@ -61,6 +62,7 @@ fn include_glob_only_includes_matches() {
         include_patterns: vec!["src/**/*.rs".into(), "nested/keep.rs".into()],
         exclude_patterns: vec![],
         is_recursive: true,
+        recent_only: false,
     };
 
     let file_ctx = FileContext::from_root(config.clone(), &config.root_path).unwrap();
@@ -87,6 +89,7 @@ fn include_and_exclude_combined() {
         include_patterns: vec!["**/*.rs".into(), "**/*.md".into()],
         exclude_patterns: vec!["nested/*".into()],
         is_recursive: true,
+        recent_only: false,
     };
 
     let file_ctx = FileContext::from_root(config.clone(), &config.root_path).unwrap();

--- a/tests/files/output_modes.rs
+++ b/tests/files/output_modes.rs
@@ -76,6 +76,7 @@ fn test_stdout_output_mode() {
         include_patterns: vec!["**/*.rs".into()],
         exclude_patterns: vec![],
         is_recursive: true,
+        recent_only: false,
     };
 
     let mut manager = ContextManager::new(config.clone());
@@ -102,6 +103,7 @@ fn test_file_output_mode() {
         include_patterns: vec!["**/*.rs".into()],
         exclude_patterns: vec![],
         is_recursive: true,
+        recent_only: false,
     };
 
     let mut manager = ContextManager::new(config.clone());
@@ -145,6 +147,7 @@ fn test_file_output_overwrites_existing() {
         include_patterns: vec!["**/*.rs".into()],
         exclude_patterns: vec![],
         is_recursive: true,
+        recent_only: false,
     };
 
     let mut manager = ContextManager::new(config.clone());
@@ -177,6 +180,7 @@ fn test_output_with_include_exclude_patterns() {
         include_patterns: vec!["src/**/*.rs".into()],
         exclude_patterns: vec!["**/*.log".into()],
         is_recursive: true,
+        recent_only: false,
     };
 
     let mut manager = ContextManager::new(config.clone());
@@ -218,6 +222,7 @@ fn test_output_file_creation_error() {
         include_patterns: vec![],
         exclude_patterns: vec![],
         is_recursive: true,
+        recent_only: false,
     };
 
     let mut manager = ContextManager::new(config.clone());
@@ -240,6 +245,7 @@ fn test_empty_context_output() {
         include_patterns: vec!["**/*.nonexistent".into()], // No files will match
         exclude_patterns: vec![],
         is_recursive: true,
+        recent_only: false,
     };
 
     let mut manager = ContextManager::new(config.clone());
@@ -273,6 +279,7 @@ fn test_output_consistency_between_modes() {
         include_patterns: vec!["**/*.rs".into()],
         exclude_patterns: vec![],
         is_recursive: true,
+        recent_only: false,
     };
 
     let mut manager = ContextManager::new(config.clone());

--- a/tests/integration_summary_tests.rs
+++ b/tests/integration_summary_tests.rs
@@ -37,6 +37,7 @@ fn test_line_counting() {
         include_patterns: vec![],
         exclude_patterns: vec![],
         is_recursive: false,
+        recent_only: false,
     };
 
     let file_context = FileContext::from_root(config, temp_dir.path().to_str().unwrap())

--- a/tests/line_counting_tests.rs
+++ b/tests/line_counting_tests.rs
@@ -42,6 +42,7 @@ fn test_single_line_file() {
         include_patterns: vec![],
         exclude_patterns: vec![],
         is_recursive: false,
+        recent_only: false,
     };
 
     let file_context = FileContext::from_root(config, temp_dir.path().to_str().unwrap())
@@ -67,6 +68,7 @@ fn test_multi_line_file() {
         include_patterns: vec![],
         exclude_patterns: vec![],
         is_recursive: false,
+        recent_only: false,
     };
 
     let file_context = FileContext::from_root(config, temp_dir.path().to_str().unwrap())
@@ -90,6 +92,7 @@ fn test_empty_file() {
         include_patterns: vec![],
         exclude_patterns: vec![],
         is_recursive: false,
+        recent_only: false,
     };
 
     let file_context = FileContext::from_root(config, temp_dir.path().to_str().unwrap())
@@ -114,6 +117,7 @@ fn test_file_without_trailing_newline() {
         include_patterns: vec![],
         exclude_patterns: vec![],
         is_recursive: false,
+        recent_only: false,
     };
 
     let file_context = FileContext::from_root(config, temp_dir.path().to_str().unwrap())
@@ -137,6 +141,7 @@ fn test_binary_file_line_count() {
         include_patterns: vec![],
         exclude_patterns: vec![],
         is_recursive: false,
+        recent_only: false,
     };
 
     let file_context = FileContext::from_root(config, temp_dir.path().to_str().unwrap())
@@ -166,6 +171,7 @@ fn test_multiple_files_line_counting() {
         include_patterns: vec![],
         exclude_patterns: vec![],
         is_recursive: false,
+        recent_only: false,
     };
 
     let file_context = FileContext::from_root(config, temp_dir.path().to_str().unwrap())
@@ -205,6 +211,7 @@ fn test_file_with_only_newlines() {
         include_patterns: vec![],
         exclude_patterns: vec![],
         is_recursive: false,
+        recent_only: false,
     };
 
     let file_context = FileContext::from_root(config, temp_dir.path().to_str().unwrap())
@@ -238,6 +245,7 @@ fn test_recursive_directory_line_counting() {
         include_patterns: vec![],
         exclude_patterns: vec![],
         is_recursive: true,
+        recent_only: false,
     };
 
     let file_context = FileContext::from_root(config, temp_dir.path().to_str().unwrap())
@@ -266,6 +274,7 @@ fn test_summary_generation() {
         include_patterns: vec![],
         exclude_patterns: vec![],
         is_recursive: false,
+        recent_only: false,
     };
 
     let file_context = FileContext::from_root(config, temp_dir.path().to_str().unwrap())

--- a/tests/output_tests.rs
+++ b/tests/output_tests.rs
@@ -153,7 +153,7 @@ mod output_context_tests {
             include_patterns: vec!["**/*.rs".into()],
             exclude_patterns: vec![],
             is_recursive: true,
-        recent_only: false,
+            recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -173,7 +173,7 @@ mod output_context_tests {
             include_patterns: vec!["**/*.rs".into()],
             exclude_patterns: vec![],
             is_recursive: true,
-        recent_only: false,
+            recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -198,7 +198,7 @@ mod output_context_tests {
             include_patterns: vec!["**/*.rs".into()],
             exclude_patterns: vec![],
             is_recursive: true,
-        recent_only: false,
+            recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -235,7 +235,7 @@ mod output_context_tests {
             include_patterns: vec!["README.md".into()],
             exclude_patterns: vec![],
             is_recursive: true,
-        recent_only: false,
+            recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -266,7 +266,7 @@ mod output_context_tests {
             include_patterns: vec!["**/*.rs".into()],
             exclude_patterns: vec![],
             is_recursive: true,
-        recent_only: false,
+            recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -317,7 +317,7 @@ mod output_context_tests {
             include_patterns: vec!["Cargo.toml".into()],
             exclude_patterns: vec![],
             is_recursive: true,
-        recent_only: false,
+            recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -345,7 +345,7 @@ mod output_context_tests {
             include_patterns: vec!["src/**/*.rs".into()],
             exclude_patterns: vec!["**/*lib*".into()],
             is_recursive: true,
-        recent_only: false,
+            recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -382,7 +382,7 @@ mod output_context_tests {
             include_patterns: vec!["**/*.nonexistent".into()], // No files match
             exclude_patterns: vec![],
             is_recursive: true,
-        recent_only: false,
+            recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -423,7 +423,7 @@ mod output_context_tests {
             include_patterns: vec!["**/*.rs".into()],
             exclude_patterns: vec![],
             is_recursive: true,
-        recent_only: false,
+            recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -457,7 +457,7 @@ mod integration_tests {
             include_patterns: vec!["**/*.md".into(), "**/*.rs".into()],
             exclude_patterns: vec!["docs/**".into()],
             is_recursive: true,
-        recent_only: false,
+            recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -503,7 +503,7 @@ mod integration_tests {
             include_patterns: vec!["Cargo.toml".into()],
             exclude_patterns: vec![],
             is_recursive: true,
-        recent_only: false,
+            recent_only: false,
         };
 
         // We need separate managers since generate() consumes the context
@@ -540,7 +540,7 @@ mod integration_tests {
             include_patterns: vec!["README.md".into()],
             exclude_patterns: vec![],
             is_recursive: true,
-        recent_only: false,
+            recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);

--- a/tests/output_tests.rs
+++ b/tests/output_tests.rs
@@ -153,6 +153,7 @@ mod output_context_tests {
             include_patterns: vec!["**/*.rs".into()],
             exclude_patterns: vec![],
             is_recursive: true,
+        recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -172,6 +173,7 @@ mod output_context_tests {
             include_patterns: vec!["**/*.rs".into()],
             exclude_patterns: vec![],
             is_recursive: true,
+        recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -196,6 +198,7 @@ mod output_context_tests {
             include_patterns: vec!["**/*.rs".into()],
             exclude_patterns: vec![],
             is_recursive: true,
+        recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -232,6 +235,7 @@ mod output_context_tests {
             include_patterns: vec!["README.md".into()],
             exclude_patterns: vec![],
             is_recursive: true,
+        recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -262,6 +266,7 @@ mod output_context_tests {
             include_patterns: vec!["**/*.rs".into()],
             exclude_patterns: vec![],
             is_recursive: true,
+        recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -312,6 +317,7 @@ mod output_context_tests {
             include_patterns: vec!["Cargo.toml".into()],
             exclude_patterns: vec![],
             is_recursive: true,
+        recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -339,6 +345,7 @@ mod output_context_tests {
             include_patterns: vec!["src/**/*.rs".into()],
             exclude_patterns: vec!["**/*lib*".into()],
             is_recursive: true,
+        recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -375,6 +382,7 @@ mod output_context_tests {
             include_patterns: vec!["**/*.nonexistent".into()], // No files match
             exclude_patterns: vec![],
             is_recursive: true,
+        recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -415,6 +423,7 @@ mod output_context_tests {
             include_patterns: vec!["**/*.rs".into()],
             exclude_patterns: vec![],
             is_recursive: true,
+        recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -448,6 +457,7 @@ mod integration_tests {
             include_patterns: vec!["**/*.md".into(), "**/*.rs".into()],
             exclude_patterns: vec!["docs/**".into()],
             is_recursive: true,
+        recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);
@@ -493,6 +503,7 @@ mod integration_tests {
             include_patterns: vec!["Cargo.toml".into()],
             exclude_patterns: vec![],
             is_recursive: true,
+        recent_only: false,
         };
 
         // We need separate managers since generate() consumes the context
@@ -529,6 +540,7 @@ mod integration_tests {
             include_patterns: vec!["README.md".into()],
             exclude_patterns: vec![],
             is_recursive: true,
+        recent_only: false,
         };
 
         let mut manager = ContextManager::new(config);

--- a/tests/recent_test_files/old_file1.txt
+++ b/tests/recent_test_files/old_file1.txt
@@ -1,0 +1,1 @@
+This is an old file 1

--- a/tests/recent_test_files/old_file2.txt
+++ b/tests/recent_test_files/old_file2.txt
@@ -1,0 +1,1 @@
+This is an old file 2

--- a/tests/recent_test_files/old_file3.txt
+++ b/tests/recent_test_files/old_file3.txt
@@ -1,0 +1,1 @@
+This is an old file 3

--- a/tests/recent_test_files/recent_file1.txt
+++ b/tests/recent_test_files/recent_file1.txt
@@ -1,0 +1,1 @@
+This is a recent file 1

--- a/tests/recent_test_files/recent_file2.txt
+++ b/tests/recent_test_files/recent_file2.txt
@@ -1,0 +1,1 @@
+This is a recent file 2

--- a/tests/recent_test_files/recent_file3.txt
+++ b/tests/recent_test_files/recent_file3.txt
@@ -1,0 +1,1 @@
+This is a recent file 3

--- a/tests/summary_output_tests.rs
+++ b/tests/summary_output_tests.rs
@@ -34,6 +34,7 @@ fn test_summary_calculation() {
         include_patterns: vec![],
         exclude_patterns: vec![],
         is_recursive: false,
+        recent_only: false,
     };
 
     let file_context = FileContext::from_root(config, temp_dir.path().to_str().unwrap())

--- a/tests/unit/tree_unit_tests.rs
+++ b/tests/unit/tree_unit_tests.rs
@@ -49,6 +49,7 @@ fn test_build_tree_from_root_basic() {
         exclude_patterns: vec![],
         is_recursive: true,
         output_file: None,
+        recent_only: false,
     };
 
     let mut tree_context = TreeContext::new(config);
@@ -76,6 +77,7 @@ fn test_build_tree_from_root_with_exclude_patterns() {
         exclude_patterns: vec!["*.toml".to_string(), "tests/**".to_string()],
         is_recursive: true,
         output_file: None,
+        recent_only: false,
     };
 
     let mut tree_context = TreeContext::new(config);
@@ -103,6 +105,7 @@ fn test_build_tree_from_root_with_include_patterns() {
         exclude_patterns: vec![],
         is_recursive: true,
         output_file: None,
+        recent_only: false,
     };
 
     let mut tree_context = TreeContext::new(config);
@@ -130,6 +133,7 @@ fn test_build_tree_from_targets_with_specific_files() {
         exclude_patterns: vec![],
         is_recursive: true,
         output_file: None,
+        recent_only: false,
     };
 
     let mut tree_context = TreeContext::new(config);
@@ -158,6 +162,7 @@ fn test_build_tree_from_targets_with_directory() {
         exclude_patterns: vec![],
         is_recursive: true,
         output_file: None,
+        recent_only: false,
     };
 
     let mut tree_context = TreeContext::new(config);
@@ -188,6 +193,7 @@ fn test_build_tree_from_targets_root_directory_detection() {
         exclude_patterns: vec![],
         is_recursive: true,
         output_file: None,
+        recent_only: false,
     };
 
     let mut tree_context = TreeContext::new(config);
@@ -218,6 +224,7 @@ fn test_build_tree_from_targets_with_absolute_path() {
         exclude_patterns: vec![],
         is_recursive: true,
         output_file: None,
+        recent_only: false,
     };
 
     let mut tree_context = TreeContext::new(config);
@@ -243,6 +250,7 @@ fn test_empty_target_paths_falls_back_to_full_tree() {
         exclude_patterns: vec![],
         is_recursive: true,
         output_file: None,
+        recent_only: false,
     };
 
     let mut tree_context = TreeContext::new(config);
@@ -265,6 +273,7 @@ fn test_tree_context_new() {
         exclude_patterns: vec!["target/".to_string()],
         is_recursive: true,
         output_file: Some("output.md".to_string()),
+        recent_only: false,
     };
 
     let tree_context = TreeContext::new(config.clone());
@@ -286,6 +295,7 @@ fn test_nonexistent_target_paths() {
         exclude_patterns: vec![],
         is_recursive: true,
         output_file: None,
+        recent_only: false,
     };
 
     let mut tree_context = TreeContext::new(config);


### PR DESCRIPTION
Fixes #27 

Added the `--recent` feature.

- Add `--recent` flag to filter files modified within the last 7 days
- Updated config type in tests
- Add a folder of tests files for testing recent flag
- Done some formatting works
- Updated README.md for `--recent` flag

ref: issue-27