### PR TITLE
Add custom version flag output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,7 @@ use clap::Parser;
 #[derive(Parser)]
 #[command(name = "repo-context")]
 #[command(about = "Package repository context for LLMs")]
+#[command(version = "Repository Context Packager v0.1.0\nBuilt with Rust")]
 /// Main CLI structure for the application.
 pub struct Cli {
     /// Target paths/files to process (required)


### PR DESCRIPTION
Adds custom version string to the CLI as requested in #1.

## Changes
- Modified `src/cli.rs` to add `#[command(version = "...")]` attribute
- Custom version output now displays:
  ```
  Repository Context Packager v0.1.0
  Built with Rust
  ```

## Testing
```bash
cargo build
./target/debug/rusty-repo-context-manager --version
```

Closes #1